### PR TITLE
Redirect to stripe-samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Moved to @stripe-samples
+# Moved to stripe-samples
 
 Stripe maintains many sample applications to demonstrate our various products.  You can find all of the up-to-date versions in the [stripe-samples](https://github.com/stripe-samples) organization, here are some payment flows which use Stripe Checkout:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Moved to stripe-samples
 
-Stripe maintains many sample applications to demonstrate our various products.  You can find all of the up-to-date versions in the [stripe-samples](https://github.com/stripe-samples) organization, here are some payment flows which use Stripe Checkout:
+Stripe maintains sample applications for various products, you can browse all the up-to-date versions in the [stripe-samples](https://github.com/stripe-samples) organization.  Here are some payment flows using Stripe Checkout:
 
 - [Quickly collect one-time payments](https://github.com/stripe-samples/checkout-one-time-payments)
 - [Combine Checkout and Billing for fast subscription pages](https://github.com/stripe-samples/checkout-single-subscription)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# Sales demo of Stripe Checkout
+# Moved to @stripe-samples
+
+Stripe maintains many sample applications to demonstrate our various products.  You can find all of the up-to-date versions in the [stripe-samples](https://github.com/stripe-samples) organization, here are some payment flows which use Stripe Checkout:
+
+- [Quickly collect one-time payments](https://github.com/stripe-samples/checkout-one-time-payments)
+- [Combine Checkout and Billing for fast subscription pages](https://github.com/stripe-samples/checkout-single-subscription)
+- [Make direct charges on a connected account](https://stripe.com/docs/connect/direct-charges)
+
+---
+_Previous README for reference:_
+
+### Sales demo of Stripe Checkout
 
 Sales demo of Stripe Checkout with different locales around the world. 
 
@@ -13,7 +24,7 @@ This demo shows you how to easily create a checkout session to see what Checkout
 - BE: French; EUR; cards, Apple Pay & Google Pay, Bancontact
 - PL: Polish; PLN; cards, Apple Pay & Google Pay, P24
 
-## How to run locally
+#### How to run locally
 
 ```
 git clone git@github.com:stripe-samples/checkout-with-multiple-locales.git


### PR DESCRIPTION
This is one of a handful of sample code repos in github.com/stripe, nobody is maintaining it.  People still get directed to the repo [every day](https://github.com/stripe/checkout-sales-demo/graphs/traffic), so I'm inclined to redirect them through the README rather than delete this repo wholesale:

![image](https://user-images.githubusercontent.com/85578318/177652631-474583cc-7aa3-4dd3-8f3f-7d9fd38bc2f4.png)


The first bullet links to[`checkout-one-time-payments`](https://github.com/stripe-samples/checkout-one-time-payments) rather than [`accept-a-payment/prebuilt-checkout-page`](https://github.com/stripe-samples/accept-a-payment/tree/main/prebuilt-checkout-page) because the former has a nice GIF of the example app.